### PR TITLE
Add coordinate system test for world offset calculation

### DIFF
--- a/tests/test_coordinate_system.py
+++ b/tests/test_coordinate_system.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+import sys
+
+# Ensure the project root is on the Python path
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from MazeGeneration import MazeGenerator
+
+
+def test_world_offset_z():
+    """world_offset_z should compute proper Z offset and world offset vector."""
+    build_space = 17
+    safety_zone = 31
+    mg = MazeGenerator(
+        csv_path=Path('rail_config.csv'),
+        difficulty_range=(0, 1),
+        build_space_size=build_space,
+        safety_zone_size=safety_zone,
+        checkpoint_count=0,
+    )
+
+    offset_z = mg.world_offset_z(mg.safety_zone_size)
+    assert offset_z == 15
+
+    world_offset = (0, 0, offset_z)
+    assert world_offset == (0, 0, 15)


### PR DESCRIPTION
## Summary
- add unit test for world Z offset ensuring BuildSpace=17 and SafetyZone=31 give offset (0,0,15)

## Testing
- `pytest tests/test_coordinate_system.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6893665849f8832087c1bfb7965d38c0